### PR TITLE
Initialize Digit geometry fields

### DIFF
--- a/Examples/Projects/RollingClock/Digit.cpp
+++ b/Examples/Projects/RollingClock/Digit.cpp
@@ -1,11 +1,20 @@
 #include "Digit.h"
 
+// Constructor
+//
+// The original implementation only initialized the value-related members
+// and left geometry fields like height and position uninitialised. Using
+// those members before explicitly setting them would result in random
+// values being read, leading to unpredictable behaviour when drawing the
+// digits. We now initialise all members to sensible defaults.
 Digit::Digit(int value)
-{
-    m_value = value;
-    m_newValue = value;
-    m_frame = 0;
-}
+    : m_value(value),
+      m_newValue(value),
+      m_frame(0),
+      m_height(0),
+      m_x(0),
+      m_y(0)
+{}
 
 int Digit::Value()
 {


### PR DESCRIPTION
## Summary
- Initialize `Digit` class fields so height and position start at sensible defaults
- Document reasoning in constructor comment for clarity

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_6895504aff10832b89c920ef23e06dbb