### PR TITLE
Correct accelerometer heading in NunchuckTest example

### DIFF
--- a/Examples/InputTests/NunchuckTest/NunchuckTest.ino
+++ b/Examples/InputTests/NunchuckTest/NunchuckTest.ino
@@ -144,11 +144,12 @@ void loop() {
     Serial.println(joyY);
 
     // -------------------
-    // Joystick
+    // Accelerometer
     // -------------------
 
 
-    // Read the accelerometer (0-1023)
+    // Read the accelerometer's X, Y, and Z axes (0-1023).
+    // 512 is roughly centered; values change as the controller tilts.
     int accelX = nchuk.accelX();
     int accelY = nchuk.accelY();
     int accelZ = nchuk.accelZ();


### PR DESCRIPTION
## Summary
- Fix mislabelled second joystick section to "Accelerometer" in NunchuckTest
- Clarify comments describing accelerometer X, Y, Z readings

## Testing
- `arduino-cli version` *(fails: command not found)*
- `pio --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898027c408c832b9b073c539ec53111