### PR TITLE
Add drawText abstraction for display output

### DIFF
--- a/Examples/Projects/RollingClockWithWifiManager/RollingClockWithWifiManager/RollingClockLogic.h
+++ b/Examples/Projects/RollingClockWithWifiManager/RollingClockWithWifiManager/RollingClockLogic.h
@@ -227,13 +227,13 @@ void DrawDate()
         int h = tft.fontHeight();
         tft.fillRect(0, 210 - h, 320, h, TFT_BLACK);
 
-        tft.drawString(buffer, 320 / 2, 210);
+        projectDisplay->drawText(buffer, 320 / 2, 210, clockFontColor, clockBackgroundColor, clockFont, true);
 
         int dow = weekday(local);
         String dayNames[] = {"", "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
         tft.setTextSize(4);
         tft.fillRect(0, 170 - h, 320, h, TFT_BLACK);
-        tft.drawString(dayNames[dow], 320 / 2, 170);
+        projectDisplay->drawText(dayNames[dow], 320 / 2, 170, clockFontColor, clockBackgroundColor, clockFont, true);
     }
 }
 

--- a/Examples/Projects/RollingClockWithWifiManager/RollingClockWithWifiManager/cheapYellowLCD.h
+++ b/Examples/Projects/RollingClockWithWifiManager/RollingClockWithWifiManager/cheapYellowLCD.h
@@ -24,24 +24,29 @@ public:
     tft.fillScreen(TFT_BLACK);
   }
 
+  void drawText(const String &text, int x, int y, uint16_t fg = defaultColor, uint16_t bg = defaultBg, int font = defaultFont, bool center = false)
+  {
+    tft.setTextColor(fg, bg);
+    if (center)
+    {
+      tft.drawCentreString(text, x, y, font);
+    }
+    else
+    {
+      tft.drawString(text, x, y, font);
+    }
+  }
+
   void drawWifiManagerMessage(WiFiManager *myWiFiManager)
   {
     Serial.println("Entered Conf Mode");
     tft.fillScreen(TFT_BLACK);
-    tft.setTextColor(TFT_WHITE, TFT_BLACK);
-    tft.drawCentreString("Entered Conf Mode:", screenCenterX, 5, 2);
-    tft.drawString("Connect to the following WIFI AP:", 5, 28, 2);
-    tft.setTextColor(TFT_BLUE, TFT_BLACK);
-    tft.drawString(myWiFiManager->getConfigPortalSSID(), 20, 48, 2);
-    tft.setTextColor(TFT_WHITE, TFT_BLACK);
-    tft.drawString("Password:", 5, 64, 2);
-    tft.setTextColor(TFT_BLUE, TFT_BLACK);
-    tft.drawString("brianlough", 20, 82, 2);
-    tft.setTextColor(TFT_WHITE, TFT_BLACK);
-
-    tft.drawString("If it doesn't AutoConnect, use this IP:", 5, 110, 2);
-    tft.setTextColor(TFT_BLUE, TFT_BLACK);
-    tft.drawString(WiFi.softAPIP().toString(), 20, 128, 2);
-    tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    drawText("Entered Conf Mode:", screenCenterX, 5, TFT_WHITE, TFT_BLACK, 2, true);
+    drawText("Connect to the following WIFI AP:", 5, 28, TFT_WHITE, TFT_BLACK, 2);
+    drawText(myWiFiManager->getConfigPortalSSID(), 20, 48, TFT_BLUE, TFT_BLACK, 2);
+    drawText("Password:", 5, 64, TFT_WHITE, TFT_BLACK, 2);
+    drawText("brianlough", 20, 82, TFT_BLUE, TFT_BLACK, 2);
+    drawText("If it doesn't AutoConnect, use this IP:", 5, 110, TFT_WHITE, TFT_BLACK, 2);
+    drawText(WiFi.softAPIP().toString(), 20, 128, TFT_BLUE, TFT_BLACK, 2);
   }
 };

--- a/Examples/Projects/RollingClockWithWifiManager/RollingClockWithWifiManager/projectDisplay.h
+++ b/Examples/Projects/RollingClockWithWifiManager/RollingClockWithWifiManager/projectDisplay.h
@@ -2,12 +2,20 @@
 #ifndef PROJECTDISPLAY_H
 #define PROJECTDISPLAY_H
 
+#include <Arduino.h>
+
 class ProjectDisplay
 {
 public:
+  static const uint16_t defaultColor = 0xFFFF;
+  static const uint16_t defaultBg = 0x0000;
+  static const int defaultFont = 2;
+
   virtual void displaySetup() = 0;
 
   virtual void drawWifiManagerMessage(WiFiManager *myWiFiManager) = 0;
+
+  virtual void drawText(const String &text, int x, int y, uint16_t fg = defaultColor, uint16_t bg = defaultBg, int font = defaultFont, bool center = false) = 0;
 
   void setWidth(int w)
   {

--- a/Examples/Projects/RollingClockWithWifiManager/RollingClockWithWifiManager/serialDisplay.h
+++ b/Examples/Projects/RollingClockWithWifiManager/RollingClockWithWifiManager/serialDisplay.h
@@ -8,8 +8,19 @@ public:
     Serial.println("Serial Display Setup");
   }
 
+  void drawText(const String &text, int x, int y, uint16_t fg = defaultColor, uint16_t bg = defaultBg, int font = defaultFont, bool center = false)
+  {
+    Serial.printf("%s\n", text.c_str());
+  }
+
   void drawWifiManagerMessage(WiFiManager *myWiFiManager)
   {
-    Serial.println("Entered Conf Mode");
+    drawText("Entered Conf Mode:", 0, 0);
+    drawText("Connect to the following WIFI AP:", 0, 0);
+    drawText(myWiFiManager->getConfigPortalSSID(), 0, 0);
+    drawText("Password:", 0, 0);
+    drawText("brianlough", 0, 0);
+    drawText("If it doesn't AutoConnect, use this IP:", 0, 0);
+    drawText(WiFi.softAPIP().toString(), 0, 0);
   }
 };


### PR DESCRIPTION
## Summary
- Introduce `drawText` virtual method in `ProjectDisplay` with default styling
- Implement `drawText` for TFT and serial displays and refactor WiFi Manager messages
- Update rolling clock logic to render text via the display interface

## Testing
- `arduino-cli version` *(fails: command not found)*
- `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh` *(fails: The requested URL returned error: 403)*

------
https://chatgpt.com/codex/tasks/task_e_6898026612d8832b9873a81a4061e706