### PR TITLE
Add JPEG touch menu example

### DIFF
--- a/Examples/Projects/JpegTouchMenu/JpegTouchMenu.ino
+++ b/Examples/Projects/JpegTouchMenu/JpegTouchMenu.ino
@@ -1,0 +1,90 @@
+/*
+  JpegTouchMenu example for the ESP32 Cheap Yellow Display.
+  Loads a JPEG background and uses touch hotspots.
+*/
+
+#include <TFT_eSPI.h>
+#include <TJpg_Decoder.h>
+#include <XPT2046_Bitbang.h>
+#include <SPI.h>
+#include <SD.h>
+
+#define XPT2046_IRQ 36
+#define XPT2046_MOSI 32
+#define XPT2046_MISO 39
+#define XPT2046_CLK 25
+#define XPT2046_CS 33
+#define SD_CS 5
+#define LED_PIN 2
+
+// Touch calibration values
+#define TOUCH_MINX 200
+#define TOUCH_MAXX 3900
+#define TOUCH_MINY 200
+#define TOUCH_MAXY 3800
+
+TFT_eSPI tft = TFT_eSPI();
+SPIClass sdSpi = SPIClass(VSPI);
+XPT2046_Bitbang ts = XPT2046_Bitbang(XPT2046_MOSI, XPT2046_MISO, XPT2046_CLK, XPT2046_CS);
+
+bool tft_output(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *bitmap) {
+  if (y >= tft.height()) return 0;
+  tft.pushImage(x, y, w, h, bitmap);
+  return 1;
+}
+
+void drawJpeg(const char *filename, int16_t x, int16_t y) {
+  TJpgDec.drawSdJpg(filename, x, y);
+}
+
+struct Hotspot {
+  int16_t x;
+  int16_t y;
+  int16_t w;
+  int16_t h;
+};
+
+Hotspot btn1 = {20, 180, 100, 60};
+Hotspot btn2 = {200, 180, 100, 60};
+
+void setup() {
+  Serial.begin(115200);
+
+  pinMode(LED_PIN, OUTPUT);
+
+  tft.init();
+  tft.setRotation(1);
+  tft.setSwapBytes(true);
+
+  ts.begin();
+
+  sdSpi.begin(18, 19, 23, SD_CS);
+  if (!SD.begin(SD_CS, sdSpi)) {
+    Serial.println("SD init failed!");
+    while (true) delay(1);
+  }
+
+  TJpgDec.setSwapBytes(true);
+  TJpgDec.setCallback(tft_output);
+
+  drawJpeg("/menu.jpg", 0, 0);
+}
+
+void loop() {
+  TouchPoint p = ts.getTouch();
+  if (p.zRaw > 0) {
+    int16_t x = map(p.xRaw, TOUCH_MINX, TOUCH_MAXX, 0, tft.width());
+    int16_t y = map(p.yRaw, TOUCH_MINY, TOUCH_MAXY, 0, tft.height());
+
+    if (x > btn1.x && x < btn1.x + btn1.w && y > btn1.y && y < btn1.y + btn1.h) {
+      Serial.println("Button 1");
+      digitalWrite(LED_PIN, !digitalRead(LED_PIN));
+      delay(300);
+    } else if (x > btn2.x && x < btn2.x + btn2.w && y > btn2.y && y < btn2.y + btn2.h) {
+      Serial.println("Button 2");
+      delay(300);
+    }
+  }
+  delay(20);
+}
+

--- a/Examples/Projects/JpegTouchMenu/README.md
+++ b/Examples/Projects/JpegTouchMenu/README.md
@@ -1,0 +1,15 @@
+# JpegTouchMenu
+
+Loads a JPEG menu background from the SD card and uses touch hotspots to trigger actions.
+
+## SD card setup
+
+* Format an SD card as FAT32.
+* Copy `menu.jpg` to the root of the card.
+* Insert the card into the display before powering on.
+
+## Touch calibration
+
+Raw touch values need to be mapped to the screen coordinates. Run the calibration example from the [`XPT2046_Bitbang`](https://github.com/TheNitek/XPT2046_Bitbang_Arduino_Library) library to obtain the minimum and maximum `x`/`y` values for your panel. Update the `TOUCH_MIN*` and `TOUCH_MAX*` defines in the sketch with your results.
+
+The default sketch defines two hotspots matching buttons drawn in `menu.jpg`. Touching a hotspot toggles the built-in LED or prints a message to the serial monitor.

--- a/Examples/Projects/JpegTouchMenu/platformio.ini
+++ b/Examples/Projects/JpegTouchMenu/platformio.ini
@@ -1,0 +1,50 @@
+[platformio]
+src_dir = .
+default_envs = cyd
+
+[env]
+platform = espressif32
+board = esp32dev
+framework = arduino
+lib_deps =
+        bodmer/TFT_eSPI@^2.5.43
+        bodmer/TJpg_Decoder@^1.1.0
+        nitek/XPT2046_Bitbang_Slim@^2.0.0
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+upload_speed = 921600
+board_build.partitions=min_spiffs.csv
+board_build.arduino.upstream_packages = no
+build_flags =
+        -DUSER_SETUP_LOADED
+        -DTFT_MISO=12
+        -DTFT_MOSI=13
+        -DTFT_SCLK=14
+        -DTFT_CS=15
+        -DUSE_HSPI_PORT
+        -DTFT_DC=2
+        -DTFT_RST=-1
+        -DTFT_BL=21
+        -DTFT_BACKLIGHT_ON=HIGH
+        -DSPI_FREQUENCY=55000000
+        -DSPI_READ_FREQUENCY=20000000
+        -DSPI_TOUCH_FREQUENCY=2500000
+        -DLOAD_GLCD
+        -DLOAD_FONT2
+        -DLOAD_FONT4
+        -DLOAD_FONT6
+        -DLOAD_FONT7
+        -DLOAD_FONT8
+        -DLOAD_GFXFF
+        -DSMOOTH_FONT=0
+
+[env:cyd]
+build_flags =
+        ${env.build_flags}
+        -DILI9341_2_DRIVER
+
+[env:cyd2usb]
+build_flags =
+        ${env.build_flags}
+        -DST7789_DRIVER
+        -DTFT_INVERSION_OFF


### PR DESCRIPTION
## Summary
- add JpegTouchMenu project that draws a JPEG menu background and handles touch hotspots
- document SD card setup and touch calibration

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68980928271c832b81edeaa2acc6575f