### PR TITLE
Refactor PipeWire mixer into modular components

### DIFF
--- a/Projects/PipewireMixer/README.md
+++ b/Projects/PipewireMixer/README.md
@@ -1,0 +1,40 @@
+# Pipewire Mixer
+
+This directory contains a proof-of-concept GNOME/GTK application that wraps common
+PipeWire command line tooling to provide a lightweight patch bay with integrated
+volume faders and MIDI controller support.  The implementation is intentionally
+self-contained and avoids any bespoke PipeWire bindings, making it suitable for
+quick experimentation on Debian-based distributions.
+
+The application takes inspiration from the routing workflow provided by
+[`qpwgraph`](https://github.com/rncbc/qpwgraph) while adding a dedicated
+"Mix" tab that exposes faders for every detected audio sink.  Each fader can be
+mapped to an external MIDI channel/CC pair, allowing hardware controllers to
+manipulate PipeWire volumes.
+
+## Architecture
+
+- `environment.py` encapsulates optional dependencies (GTK/libadwaita and MIDI)
+  so the rest of the codebase can assume their presence.
+- `backend.py` and `models.py` provide a thin abstraction over PipeWire's
+  command-line tools and graph data.
+- `ui/` hosts reusable GTK widgets for the routing and mixing tabs.
+- `app.py` wires everything together using libadwaita conventions, while
+  `main.py` stays responsible for dependency validation.
+
+## Running
+
+```bash
+python3 -m Projects.PipewireMixer.main
+```
+
+Dependencies:
+
+- Python 3.10+
+- `python3-gi` / GTK 4
+- PipeWire command line tools (`pw-dump`, `pw-link`, `wpctl`)
+- Optional: [`mido`](https://mido.readthedocs.io/) with the `python-rtmidi` backend
+  for MIDI controller integration
+
+The program degrades gracefully if either GTK or the MIDI dependencies are
+missing, providing helpful error messages when executed in such environments.

--- a/Projects/PipewireMixer/__init__.py
+++ b/Projects/PipewireMixer/__init__.py
@@ -1,0 +1,10 @@
+"""PipeWire mixer package."""
+
+__all__ = [
+    "environment",
+    "models",
+    "backend",
+    "midi",
+    "ui",
+    "app",
+]

--- a/Projects/PipewireMixer/app.py
+++ b/Projects/PipewireMixer/app.py
@@ -1,0 +1,53 @@
+"""Application bootstrap for the PipeWire mixer."""
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from .backend import PipewireBackend
+from .environment import Adw, Gio, Gtk
+from .midi import MidiController
+from .ui import MixView, RoutingView
+
+
+class MixerWindow(Adw.ApplicationWindow):
+    """Main application window containing the routing and mix tabs."""
+
+    def __init__(self, app: Gtk.Application, backend: PipewireBackend, midi: MidiController):
+        super().__init__(application=app)
+        self.set_title("PipeWire Mixer")
+        self.set_default_size(900, 600)
+
+        notebook = Gtk.Notebook()
+        # Tabs keep routing and mixing concerns separate while sharing the same
+        # backend instances so selections remain in sync across the UI.
+        notebook.append_page(RoutingView(backend), Gtk.Label(label="Routing"))
+        notebook.append_page(MixView(backend, midi), Gtk.Label(label="Mix"))
+
+        self.set_content(notebook)
+
+
+class MixerApplication(Adw.Application):
+    """GTK application entry point."""
+
+    def __init__(self) -> None:
+        super().__init__(application_id="com.example.PipewireMixer", flags=Gio.ApplicationFlags.FLAGS_NONE)
+        # Singletons live on the application object so they can be reused across
+        # multiple windows in the future without additional plumbing.
+        self.backend = PipewireBackend()
+        self.midi = MidiController()
+
+    def do_activate(self) -> None:  # type: ignore[override]
+        window = self.props.active_window
+        if window is None:
+            window = MixerWindow(self, self.backend, self.midi)
+        window.present()
+
+
+def run_application(argv: Optional[Iterable[str]] = None) -> int:
+    """Run the GTK application and return its exit status."""
+
+    app = MixerApplication()
+    return app.run(list(argv or []))
+
+
+__all__ = ["MixerApplication", "MixerWindow", "run_application"]

--- a/Projects/PipewireMixer/backend.py
+++ b/Projects/PipewireMixer/backend.py
@@ -1,0 +1,181 @@
+"""Interaction helpers for the PipeWire command-line tools."""
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Dict, List, Optional
+
+from .models import PipewireNode, PipewirePort
+
+
+class PipewireBackend:
+    """Expose discovery, routing, and volume helpers for PipeWire.
+
+    The class isolates all subprocess invocations so that the remainder of the
+    codebase can focus on GUI logic.  It also caches discovery information in
+    memory; recomputing the cache is cheap enough that the public methods
+    simply call :meth:`refresh` when necessary instead of maintaining a
+    long-lived background thread.
+    """
+
+    def __init__(self) -> None:
+        # Discovery results are cached so that UI refreshes can reuse the same
+        # objects without continuously shelling out to ``pw-dump``.
+        self.nodes: Dict[int, PipewireNode] = {}
+        self.ports: Dict[int, PipewirePort] = {}
+
+    # ------------------------------------------------------------------
+    # Discovery helpers
+    # ------------------------------------------------------------------
+    def refresh(self) -> None:
+        """Refresh the internal cache using ``pw-dump``."""
+
+        try:
+            dump = subprocess.check_output(["pw-dump"], text=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            # ``pw-dump`` may be unavailable inside CI environments.  The
+            # method fails silently so the GUI can show an empty state instead
+            # of crashing.
+            return
+
+        try:
+            data = json.loads(dump)
+        except json.JSONDecodeError:
+            return
+
+        nodes: Dict[int, PipewireNode] = {}
+        ports: Dict[int, PipewirePort] = {}
+
+        for obj in data:
+            obj_id = obj.get("id")
+            if obj_id is None:
+                continue
+            info = obj.get("info", {})
+            props = obj.get("props", {})
+            obj_type = obj.get("type")
+
+            if obj_type == "PipeWire:Interface:Node":
+                name = props.get("node.description") or props.get("node.name") or info.get("name") or f"node-{obj_id}"
+                media_class = props.get("media.class", "")
+                nodes[obj_id] = PipewireNode(id=obj_id, name=name, media_class=media_class)
+            elif obj_type == "PipeWire:Interface:Port":
+                node_id = info.get("node.id") or props.get("node.id")
+                if node_id is None:
+                    continue
+                node_name = props.get("node.name") or props.get("port.alias") or props.get("port.name") or f"node-{node_id}"
+                direction_raw = info.get("direction") or props.get("port.direction")
+                direction = self._normalize_direction(direction_raw)
+                port_name = props.get("port.alias") or props.get("port.name") or info.get("name") or f"port-{obj_id}"
+                ports[obj_id] = PipewirePort(
+                    id=obj_id,
+                    name=port_name,
+                    direction=direction,
+                    node_id=node_id,
+                    node_name=node_name,
+                )
+
+        # Attach ports to their respective nodes so the UI can avoid repeated
+        # lookups and simply walk the already filtered collections.
+        for port in ports.values():
+            node = nodes.get(port.node_id)
+            if node is None:
+                continue
+            if port.direction == "output":
+                node.outputs.append(port)
+            else:
+                node.inputs.append(port)
+
+        self.nodes = nodes
+        self.ports = ports
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_direction(direction: object) -> str:
+        """Translate PipeWire direction values into ``"input"`` or ``"output"``."""
+
+        if isinstance(direction, str):
+            # PipeWire occasionally returns short-hand strings; normalizing to
+            # lower-case allows us to cover every variant with a tiny lookup.
+            normalized = direction.lower()
+            if normalized in {"in", "input"}:
+                return "input"
+            if normalized in {"out", "output"}:
+                return "output"
+        if isinstance(direction, int):
+            return "input" if direction else "output"
+        return "input"
+
+    # ------------------------------------------------------------------
+    def get_source_ports(self) -> List[PipewirePort]:
+        """Return all output ports sorted by node and port name."""
+
+        return sorted(
+            (p for p in self.ports.values() if p.direction == "output"),
+            key=lambda p: (p.node_name, p.name),
+        )
+
+    def get_sink_ports(self) -> List[PipewirePort]:
+        """Return all input ports sorted by node and port name."""
+
+        return sorted(
+            (p for p in self.ports.values() if p.direction == "input"),
+            key=lambda p: (p.node_name, p.name),
+        )
+
+    def get_audio_sinks(self) -> List[PipewireNode]:
+        """Return nodes that act as audio sinks sorted alphabetically."""
+
+        return sorted((n for n in self.nodes.values() if n.is_audio_sink), key=lambda n: n.name.lower())
+
+    # ------------------------------------------------------------------
+    def connect(self, src_port: PipewirePort, dst_port: PipewirePort) -> bool:
+        """Link two ports using ``pw-link``."""
+
+        try:
+            subprocess.check_call(["pw-link", str(src_port.id), str(dst_port.id)])
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            return False
+        return True
+
+    def disconnect(self, src_port: PipewirePort, dst_port: PipewirePort) -> bool:
+        """Unlink two ports using ``pw-link -d``."""
+
+        try:
+            subprocess.check_call(["pw-link", "-d", str(src_port.id), str(dst_port.id)])
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    def get_volume(self, node_id: int) -> Optional[float]:
+        """Return the node volume reported by ``wpctl``."""
+
+        try:
+            out = subprocess.check_output(["wpctl", "get-volume", str(node_id)], text=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            return None
+        # ``wpctl get-volume`` returns strings such as ``"Volume: 0.75"``; we
+        # therefore parse every token until we encounter a float.
+        parts = out.strip().split()
+        for token in parts:
+            try:
+                return float(token)
+            except ValueError:
+                continue
+        return None
+
+    def set_volume(self, node_id: int, value: float) -> bool:
+        """Update the node volume using ``wpctl`` with clipping protection."""
+
+        # Volumes above ``1.0`` boost the signal.  We allow modest boosts up to
+        # ``1.5`` but clamp everything else to avoid accidental clipping from
+        # MIDI inputs.
+        clamped = max(0.0, min(1.5, value))
+        try:
+            subprocess.check_call(["wpctl", "set-volume", str(node_id), f"{clamped:.3f}"])
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            return False
+        return True
+
+
+__all__ = ["PipewireBackend"]

--- a/Projects/PipewireMixer/environment.py
+++ b/Projects/PipewireMixer/environment.py
@@ -1,0 +1,73 @@
+"""Helpers for optional third-party dependencies.
+
+This module keeps dependency discovery in a single location so that other
+modules can simply import the symbols they need.  The approach avoids
+sprinkling conditional imports around the codebase and makes unit testing
+simpler because every dependent module can patch this module instead of the
+upstream packages.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from types import ModuleType
+from typing import Optional, Tuple
+
+
+def _load_gi_modules() -> Tuple[Optional[ModuleType], Optional[ModuleType], Optional[ModuleType], Optional[ModuleType], Optional[ModuleType]]:
+    """Attempt to load GTK/libadwaita bindings.
+
+    The loader intentionally avoids ``try/except`` around the import
+    statements.  Instead it inspects module specifications first; only when
+    a module is advertised as present do we request it via
+    :func:`importlib.import_module`.  If any intermediate step fails the
+    function returns ``None`` placeholders so that callers can react without
+    raising immediate ImportErrors.
+    """
+
+    if importlib.util.find_spec("gi") is None:
+        return None, None, None, None, None
+
+    # ``importlib`` keeps the logic compact while still avoiding ``try``/``except``
+    # blocks around the import statement itself as mandated by the project's
+    # guidelines.
+    gi_module = importlib.import_module("gi")
+
+    # ``require_version`` raises ``ValueError`` when the bindings are missing
+    # the requested ABI; this is caught so the UI layer can degrade gracefully.
+    try:
+        gi_module.require_version("Gtk", "4.0")
+        gi_module.require_version("Adw", "1")
+    except ValueError:
+        return None, None, None, None, None
+
+    module_names = ["Adw", "Gio", "GLib", "Gtk"]
+    loaded: list[Optional[ModuleType]] = [gi_module]
+    for name in module_names:
+        if importlib.util.find_spec(f"gi.repository.{name}") is None:
+            return None, None, None, None, None
+        loaded.append(importlib.import_module(f"gi.repository.{name}"))
+    # ``loaded`` now holds ``[gi, Adw, Gio, GLib, Gtk]`` as modules.
+    return tuple(loaded)  # type: ignore[return-value]
+
+
+gi, Adw, Gio, GLib, Gtk = _load_gi_modules()
+
+
+def load_mido() -> Optional[ModuleType]:
+    """Load the ``mido`` package on demand.
+
+    The MIDI layer does not strictly depend on the library.  By exposing the
+    helper we can keep module level state inside :mod:`midi` reusable in unit
+    tests without having to mock ``importlib`` directly.
+    """
+
+    # ``mido`` is optional; returning ``None`` allows callers to disable MIDI
+    # functionality without raising import errors on systems that only need the
+    # audio routing capabilities.
+    if importlib.util.find_spec("mido") is None:
+        return None
+    return importlib.import_module("mido")
+
+
+__all__ = ["gi", "Adw", "Gio", "GLib", "Gtk", "load_mido"]

--- a/Projects/PipewireMixer/main.py
+++ b/Projects/PipewireMixer/main.py
@@ -1,0 +1,26 @@
+"""Executable entry point for the PipeWire mixer."""
+from __future__ import annotations
+
+import sys
+from typing import Iterable, Optional
+
+from .environment import Adw, Gio, Gtk
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    """Validate dependencies and dispatch to the GTK application."""
+
+    # Dependency validation happens here to keep :mod:`app` lean and focused on
+    # UI composition.
+    if Gtk is None or Adw is None or Gio is None:
+        sys.stderr.write("GTK/libadwaita not available. Install python3-gi and libadwaita bindings.\n")
+        return 1
+    # Importing here prevents ``Gtk`` dependent modules from loading before we
+    # validate the environment.
+    from .app import run_application
+
+    return run_application(argv or sys.argv)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/Projects/PipewireMixer/midi.py
+++ b/Projects/PipewireMixer/midi.py
@@ -1,0 +1,95 @@
+"""MIDI controller bindings for mixer faders."""
+from __future__ import annotations
+
+import threading
+from typing import Dict, Optional, Tuple
+
+from .environment import GLib, Gtk, load_mido
+
+mido = load_mido()
+
+
+class MidiController:
+    """Handle MIDI Continuous Controller messages for GTK sliders."""
+
+    def __init__(self) -> None:
+        # ``mido`` exposes ``BaseInput`` objects that we store generically to
+        # avoid importing optional typing helpers from the library itself.
+        self._input: Optional[object] = None
+        self._bindings: Dict[Tuple[int, int], Gtk.Scale] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    @property
+    def available(self) -> bool:
+        """Return ``True`` when both GTK and ``mido`` are available."""
+
+        return mido is not None and Gtk is not None and GLib is not None
+
+    def get_ports(self) -> list[str]:
+        """Return all available MIDI input port names."""
+
+        if not self.available:
+            return []
+        # Sorting the ports keeps the UI deterministic even when the ALSA
+        # enumeration order changes between boots.
+        return sorted(mido.get_input_names())  # type: ignore[no-any-return]
+
+    def open(self, name: Optional[str]) -> bool:
+        """Open the selected MIDI input port and attach a callback."""
+
+        if not self.available:
+            return False
+        with self._lock:
+            if self._input is not None:
+                # Closing the previous input ensures we never leak file
+                # descriptors when the user switches ports repeatedly.
+                self._input.close()
+                self._input = None
+            if not name:
+                return True
+            try:
+                self._input = mido.open_input(name, callback=self._handle_message)
+            except (IOError, OSError):
+                return False
+        return True
+
+    def bind(self, channel: int, control: int, slider: Gtk.Scale) -> None:
+        """Bind a slider to a MIDI channel/control pair."""
+
+        if not self.available:
+            return
+        key = (channel, control)
+        with self._lock:
+            self._bindings[key] = slider
+
+    def unbind_slider(self, slider: Gtk.Scale) -> None:
+        """Remove existing bindings referencing ``slider``."""
+
+        if not self.available:
+            return
+        with self._lock:
+            for key, bound in list(self._bindings.items()):
+                if bound is slider:
+                    self._bindings.pop(key)
+
+    # ------------------------------------------------------------------
+    def _handle_message(self, message):  # type: ignore[override]
+        """Handle incoming MIDI CC messages and update the slider value."""
+
+        if message.type != "control_change":
+            return
+        # MIDI CC values range from 0..127; scaling to ``1.5`` mirrors the
+        # volume limits enforced in :meth:`PipewireBackend.set_volume`.
+        value = message.value / 127.0 * 1.5
+        key = (message.channel + 1, message.control)
+        with self._lock:
+            slider = self._bindings.get(key)
+        if slider is None or GLib is None:
+            return
+        # ``idle_add`` marshals the update back onto the GTK main loop to keep
+        # thread interactions safe.
+        GLib.idle_add(slider.set_value, value, priority=GLib.PRIORITY_DEFAULT)
+
+
+__all__ = ["MidiController"]

--- a/Projects/PipewireMixer/models.py
+++ b/Projects/PipewireMixer/models.py
@@ -1,0 +1,42 @@
+"""Lightweight data structures describing PipeWire topology."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass(slots=True)
+class PipewirePort:
+    """Represents a single PipeWire port."""
+
+    id: int
+    name: str
+    direction: str
+    node_id: int
+    node_name: str
+
+    @property
+    def display_name(self) -> str:
+        """Return a human readable port label used in drop-down widgets."""
+
+        return f"{self.node_name} · {self.name} ({self.id})"
+
+
+@dataclass(slots=True)
+class PipewireNode:
+    """Represents a PipeWire node with its associated ports."""
+
+    id: int
+    name: str
+    media_class: str
+    inputs: List[PipewirePort] = field(default_factory=list)
+    outputs: List[PipewirePort] = field(default_factory=list)
+
+    @property
+    def is_audio_sink(self) -> bool:
+        """Return ``True`` when the node represents an audio sink."""
+
+        return self.media_class.startswith("Audio/Sink") or self.media_class.startswith("Stream/Output")
+
+
+__all__ = ["PipewirePort", "PipewireNode"]

--- a/Projects/PipewireMixer/ui/__init__.py
+++ b/Projects/PipewireMixer/ui/__init__.py
@@ -1,0 +1,6 @@
+"""UI components for the PipeWire mixer."""
+
+from .routing import RoutingView
+from .mix import MixView
+
+__all__ = ["RoutingView", "MixView"]

--- a/Projects/PipewireMixer/ui/fader.py
+++ b/Projects/PipewireMixer/ui/fader.py
@@ -1,0 +1,101 @@
+"""Individual mixer fader component."""
+from __future__ import annotations
+
+from ..backend import PipewireBackend
+from ..environment import Gtk
+from ..midi import MidiController
+from ..models import PipewireNode
+
+
+if Gtk is None:  # pragma: no cover - import guard for environments without GTK
+
+    class FaderRow:  # type: ignore[too-many-ancestors]
+        """Placeholder used when GTK is not available."""
+
+        def __init__(self, *_: object, **__: object) -> None:
+            raise RuntimeError("GTK is required for FaderRow")
+
+else:
+
+    class FaderRow(Gtk.Box):
+        """Single mixer fader with optional MIDI bindings."""
+
+        def __init__(self, backend: PipewireBackend, midi: MidiController, node: PipewireNode):
+            super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+            self.set_margin_top(6)
+            self.set_margin_bottom(6)
+            self.set_margin_start(6)
+            self.set_margin_end(6)
+            self.backend = backend
+            self.midi = midi
+            self.node = node
+
+            # The header surfaces the node name and wraps it to avoid overly
+            # wide tiles when descriptive names are used.
+            header = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
+            header.append(Gtk.Label(label=node.name, wrap=True, justify=Gtk.Justification.CENTER))
+
+            self.scale = Gtk.Scale.new_with_range(Gtk.Orientation.VERTICAL, 0.0, 1.5, 0.01)
+            self.scale.set_vexpand(True)
+            self.scale.set_value_pos(Gtk.PositionType.BOTTOM)
+            self.scale.connect("value-changed", self._on_value_changed)
+
+            # MIDI controls live underneath the slider so each tile remains a
+            # self-contained unit during layout changes.
+            controls = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
+            self.channel_spin = Gtk.SpinButton.new_with_range(1, 16, 1)
+            self.channel_spin.set_value(1)
+            self.channel_spin.connect("value-changed", self._update_binding)
+            controls.append(Gtk.Label(label="MIDI Ch."))
+            controls.append(self.channel_spin)
+
+            self.cc_spin = Gtk.SpinButton.new_with_range(0, 127, 1)
+            self.cc_spin.set_value(7)
+            self.cc_spin.connect("value-changed", self._update_binding)
+            controls.append(Gtk.Label(label="CC"))
+            controls.append(self.cc_spin)
+
+            # ``Sync`` allows the user to restore GTK state after external
+            # volume changes (e.g., via ``wpctl set-volume`` in another
+            # terminal).
+            refresh_button = Gtk.Button(label="Sync")
+            refresh_button.connect("clicked", lambda *_: self.sync_from_backend())
+            controls.append(refresh_button)
+
+            self.append(header)
+            self.append(self.scale)
+            self.append(controls)
+
+            self.sync_from_backend()
+            self._update_binding()
+
+        # ------------------------------------------------------------------
+        def sync_from_backend(self) -> None:
+            """Synchronize the slider position with the backend volume."""
+
+            volume = self.backend.get_volume(self.node.id)
+            if volume is not None:
+                self.scale.set_value(volume)
+
+        def _on_value_changed(self, scale: Gtk.Scale) -> None:
+            value = scale.get_value()
+            success = self.backend.set_volume(self.node.id, value)
+            if not success:
+                # Tooltips double as lightweight status messages without
+                # bloating the UI with extra labels.
+                scale.set_tooltip_text("Failed to set volume via wpctl.")
+            else:
+                scale.set_tooltip_text(None)
+
+        def _update_binding(self, *_: object) -> None:
+            if not self.midi.available:
+                return
+            # Rebinding clears the previous assignment before applying the new
+            # channel/CC pair entered by the user.
+            self.midi.unbind_slider(self.scale)
+            channel = int(self.channel_spin.get_value())
+            control = int(self.cc_spin.get_value())
+            self.midi.bind(channel, control, self.scale)
+
+
+__all__ = ["FaderRow"]

--- a/Projects/PipewireMixer/ui/mix.py
+++ b/Projects/PipewireMixer/ui/mix.py
@@ -1,0 +1,86 @@
+"""Mixer tab with dynamic faders and MIDI bindings."""
+from __future__ import annotations
+
+from ..backend import PipewireBackend
+from ..environment import Gtk
+from ..midi import MidiController
+from .fader import FaderRow
+
+
+if Gtk is None:  # pragma: no cover - import guard for environments without GTK
+
+    class MixView:  # type: ignore[too-many-ancestors]
+        """Placeholder used when GTK is not available."""
+
+        def __init__(self, *_: object, **__: object) -> None:
+            raise RuntimeError("GTK is required for MixView")
+
+else:
+
+    class MixView(Gtk.Box):
+        """Container for the mixer tab."""
+
+        def __init__(self, backend: PipewireBackend, midi: MidiController):
+            super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+            self.backend = backend
+            self.midi = midi
+
+            # The header mirrors the routing tab by exposing refresh and MIDI
+            # selection widgets in a single row.
+            header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+            header.set_margin_top(6)
+            header.set_margin_start(6)
+            header.set_margin_end(6)
+            refresh_button = Gtk.Button(label="Refresh")
+            refresh_button.connect("clicked", lambda *_: self.refresh())
+            header.append(refresh_button)
+
+            if midi.available:
+                header.append(Gtk.Label(label="MIDI Input:"))
+                self.midi_ports = Gtk.DropDown.new_from_strings(midi.get_ports())
+                self.midi_ports.connect("notify::selected", self._on_midi_selected)
+                header.append(self.midi_ports)
+            else:
+                header.append(Gtk.Label(label="MIDI support requires python-mido", xalign=0.0))
+
+            self.append(header)
+
+            # ``Gtk.FlowBox`` automatically wraps faders, keeping the UI usable
+            # even when dozens of sinks are present.
+            self.flow = Gtk.FlowBox()
+            self.flow.set_selection_mode(Gtk.SelectionMode.NONE)
+            self.flow.set_valign(Gtk.Align.START)
+            self.append(self.flow)
+
+            self.refresh()
+
+        # ------------------------------------------------------------------
+        def refresh(self) -> None:
+            """Recreate faders for every discovered audio sink."""
+
+            self.backend.refresh()
+            # Removing stale faders prevents memory leaks when the PipeWire
+            # graph changes (e.g., when USB devices are unplugged).
+            for child in list(self.flow.get_children()):
+                self.flow.remove(child)
+            sinks = self.backend.get_audio_sinks()
+            if not sinks:
+                placeholder = Gtk.Label(label="No audio sinks detected. Is PipeWire running?", xalign=0.5)
+                self.flow.append(placeholder)
+                return
+            for node in sinks:
+                row = FaderRow(self.backend, self.midi, node)
+                self.flow.append(row)
+
+        def _on_midi_selected(self, dropdown: Gtk.DropDown, *_: object) -> None:
+            if not self.midi.available:
+                return
+            index = dropdown.get_selected()
+            ports = self.midi.get_ports()
+            # ``Gtk.DropDown`` returns ``-1`` when nothing is selected; the
+            # guard avoids ``IndexError`` when toggling between ports quickly.
+            name = ports[index] if 0 <= index < len(ports) else None
+            self.midi.open(name)
+
+
+__all__ = ["MixView"]

--- a/Projects/PipewireMixer/ui/routing.py
+++ b/Projects/PipewireMixer/ui/routing.py
@@ -1,0 +1,151 @@
+"""Routing tab mirroring the qpwgraph workflow."""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from ..backend import PipewireBackend
+from ..environment import Gtk
+from ..models import PipewirePort
+
+
+if Gtk is None:  # pragma: no cover - import guard for environments without GTK
+
+    class RoutingView:  # type: ignore[too-many-ancestors]
+        """Placeholder used when GTK is not available."""
+
+        def __init__(self, *_: object, **__: object) -> None:
+            raise RuntimeError("GTK is required for RoutingView")
+
+else:
+
+    class RoutingView(Gtk.Box):
+        """Display routing controls similar to ``qpwgraph``."""
+
+        def __init__(self, backend: PipewireBackend):
+            super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+            self.backend = backend
+
+            # The header provides quick access to a refresh action and
+            # connection status details, mirroring ``qpwgraph``'s immediate
+            # feedback model.
+            header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+            refresh_button = Gtk.Button(label="Refresh")
+            refresh_button.connect("clicked", lambda *_: self.refresh())
+            self.status_label = Gtk.Label(xalign=0.0)
+            header.append(refresh_button)
+            header.append(self.status_label)
+
+            self.append(header)
+
+            paned = Gtk.Paned.new(Gtk.Orientation.HORIZONTAL)
+            self.append(paned)
+
+            # Drop-downs are backed by ``Gtk.StringList`` to keep the widgets
+            # lightweight.  We rebuild the model on every refresh so we can rely
+            # on indices lining up with ``backend.get_*`` results.
+            self.source_store = Gtk.StringList.new([])
+            self.source_dropdown = Gtk.DropDown()
+            self.source_dropdown.set_model(self.source_store)
+            self.source_dropdown.set_expression(Gtk.PropertyExpression.new(Gtk.StringObject, None, "string"))
+            source_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+            source_box.set_margin_top(6)
+            source_box.set_margin_bottom(6)
+            source_box.set_margin_start(6)
+            source_box.set_margin_end(6)
+            source_box.append(Gtk.Label(label="Outputs", xalign=0.0))
+            source_box.append(self.source_dropdown)
+
+            self.sink_store = Gtk.StringList.new([])
+            self.sink_dropdown = Gtk.DropDown()
+            self.sink_dropdown.set_model(self.sink_store)
+            self.sink_dropdown.set_expression(Gtk.PropertyExpression.new(Gtk.StringObject, None, "string"))
+            sink_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+            sink_box.set_margin_top(6)
+            sink_box.set_margin_bottom(6)
+            sink_box.set_margin_start(6)
+            sink_box.set_margin_end(6)
+            sink_box.append(Gtk.Label(label="Inputs", xalign=0.0))
+            sink_box.append(self.sink_dropdown)
+
+            # Connection actions live in a dedicated column to keep the
+            # workflow clear: pick output/input, then press connect or
+            # disconnect.
+            button_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+            button_box.set_margin_top(6)
+            button_box.set_margin_bottom(6)
+            connect_button = Gtk.Button(label="Connect")
+            connect_button.connect("clicked", self._handle_connect)
+            disconnect_button = Gtk.Button(label="Disconnect")
+            disconnect_button.connect("clicked", self._handle_disconnect)
+            button_box.append(connect_button)
+            button_box.append(disconnect_button)
+
+            paned.set_start_child(source_box)
+            right_box = Gtk.Box.new(Gtk.Orientation.VERTICAL, 6)
+            right_box.append(button_box)
+            right_box.append(sink_box)
+            paned.set_end_child(right_box)
+
+            self.refresh()
+
+        # ------------------------------------------------------------------
+        def refresh(self) -> None:
+            """Refresh the backend cache and rebuild the drop-down models."""
+
+            self.backend.refresh()
+            # We request fresh lists to avoid stale references should the graph
+            # change between the selection and the button press.
+            sources = self.backend.get_source_ports()
+            sinks = self.backend.get_sink_ports()
+
+            self.source_store.splice(0, self.source_store.get_n_items(), [])
+            for port in sources:
+                self.source_store.append(port.display_name)
+            self.sink_store.splice(0, self.sink_store.get_n_items(), [])
+            for port in sinks:
+                self.sink_store.append(port.display_name)
+            if sources or sinks:
+                self.status_label.set_text(f"Outputs: {len(sources)} · Inputs: {len(sinks)}")
+            else:
+                self.status_label.set_text("No PipeWire ports discovered. Ensure pw-dump is available.")
+
+        # ------------------------------------------------------------------
+        def _selected_ports(self) -> Optional[Tuple[PipewirePort, PipewirePort]]:
+            """Return the ports referenced by the currently selected rows."""
+
+            src_index = self.source_dropdown.get_selected()
+            sink_index = self.sink_dropdown.get_selected()
+            if src_index < 0 or sink_index < 0:
+                return None
+            sources = self.backend.get_source_ports()
+            sinks = self.backend.get_sink_ports()
+            if src_index >= len(sources) or sink_index >= len(sinks):
+                return None
+            return sources[src_index], sinks[sink_index]
+
+        def _handle_connect(self, *_: object) -> None:
+            ports = self._selected_ports()
+            if not ports:
+                return
+            src, sink = ports
+            # Success/failure feedback goes into the header label so the user
+            # has a single place to look for state updates.
+            success = self.backend.connect(src, sink)
+            if not success:
+                self.status_label.set_text("Failed to connect ports")
+            else:
+                self.status_label.set_text(f"Linked {src.id} → {sink.id}")
+
+        def _handle_disconnect(self, *_: object) -> None:
+            ports = self._selected_ports()
+            if not ports:
+                return
+            src, sink = ports
+            success = self.backend.disconnect(src, sink)
+            if not success:
+                self.status_label.set_text("Failed to disconnect ports")
+            else:
+                self.status_label.set_text(f"Unlinked {src.id} → {sink.id}")
+
+
+__all__ = ["RoutingView"]


### PR DESCRIPTION
## Summary
- reorganize the PipeWire mixer into a package with dedicated backend, UI, MIDI, and environment modules for improved maintainability
- add GTK availability guards and inline comments that clarify design choices across routing, mixing, and fader widgets
- update project documentation to describe the new architecture and module entry point

## Testing
- python -m py_compile Projects/PipewireMixer/*.py Projects/PipewireMixer/ui/*.py

------
https://chatgpt.com/codex/tasks/task_e_68e34ce820f0832bbc1c748087d770c6